### PR TITLE
Signal handler fix

### DIFF
--- a/linux-lts-quantal-3.5.0/compile
+++ b/linux-lts-quantal-3.5.0/compile
@@ -1,12 +1,16 @@
 #!/bin/bash
 
-if [[ $(whoami) != "root" ]]; then
+if [[ $EUID -ne 0 ]]; then
     echo "Must be run as root!"
     exit 1
 fi
 
 #stuff to setup OMNIPLAY_DIR
-user=$(who am i | awk '{print $1}')
+user=$SUDO_USER
+if [[ -z $SUDO_USER ]]; then
+  user=$(who am i | awk '{print $1}')
+fi
+
 setupfile=$(sudo -H -u $user echo $HOME/.omniplay_setup) 
 
 source $setupfile

--- a/linux-lts-quantal-3.5.0/kernel/replay.c
+++ b/linux-lts-quantal-3.5.0/kernel/replay.c
@@ -4913,8 +4913,8 @@ get_record_pending_signal (siginfo_t* info)
 }
 
 // Don't use standard debugging by default here because a printk could deadlock kernel
-#define SIGPRINT(x,...)
-//#define SIGPRINT printk
+//#define SIGPRINT(x,...)
+#define SIGPRINT printk
 
 static int defer_signal (struct record_thread* prt, int signr, siginfo_t* info)
 {
@@ -4941,39 +4941,50 @@ int get_record_ignore_flag ()
 	return ignore_flag;
 }
 
+int is_sync_signal(int signr) {
+  return signr == SIGILL || signr == SIGFPE || signr == SIGSEGV ||
+    signr == SIGBUS || signr == SIGTRAP;
+}
+
+int has_custom_handler(struct k_sigaction *ka) {
+  return ka->sa.sa_handler != SIG_IGN && ka->sa.sa_handler != SIG_DFL;
+}
+
 // This is called with interrupts disabled so there is little we can do
 // If signal is to be deferred, we do that since we can use atomic allocation.
 // mcc: Called with current->sighand->siglock held and local interrupts disabled
 long
 check_signal_delivery (int signr, siginfo_t* info, struct k_sigaction* ka, int ignore_flag)
 {
-	struct record_thread* prt = current->record_thrd;
-	int sysnum = syscall_get_nr(current, get_pt_regs(NULL));
-	struct syscall_result* psr;
+  struct record_thread* prt = current->record_thrd;
+  int sysnum = syscall_get_nr(current, get_pt_regs(NULL));
+  struct syscall_result* psr;
 
-	if (prt->rp_in_ptr == 0) {
-		SIGPRINT ("Pid %d - no syscall records yet - signal %d\n", current->pid, signr);
-		if (sig_fatal(current, signr)) {
-			SIGPRINT ("Fatal signal sent w/o recording - replay broken?\n");
-			return 0; 
-		}
-		return defer_signal (prt, signr, info);
-	}
-	psr = &prt->rp_log[(prt->rp_in_ptr-1)]; 
+  if (prt->rp_in_ptr == 0) {
+    SIGPRINT ("Pid %d - no syscall records yet - signal %d\n", current->pid, signr);
+    if (sig_fatal(current, signr)) {
+      SIGPRINT ("Fatal signal sent w/o recording - replay broken?\n");
+      return 0; 
+    }
+    return defer_signal (prt, signr, info);
+  }
+  psr = &prt->rp_log[(prt->rp_in_ptr-1)]; 
 
-        SIGPRINT ("Pid %d check signal delivery signr %d fatal %d - clock is currently %d ignore flag %d sysnum %d psr->sysnum %d handler %p\n", 
-		  current->pid, signr, sig_fatal(current, signr), atomic_read(prt->rp_precord_clock), ignore_flag, sysnum, psr->sysnum, ka->sa.sa_handler);
+  SIGPRINT ("Pid %d check signal delivery signr %d fatal %d - clock is currently %d ignore flag %d sysnum %d psr->sysnum %d handler %p\n", 
+      current->pid, signr, sig_fatal(current, signr), atomic_read(prt->rp_precord_clock), ignore_flag, sysnum, psr->sysnum, ka->sa.sa_handler);
 
-	if (ignore_flag && sysnum >= 0) {
-		return 0;
-	} else if (!sig_fatal(current,signr) && sysnum != psr->sysnum && sysnum != 0 /* restarted syscall */) {
-		// This is an unrecorded system call or a trap.  Since we cannot guarantee that the signal will not delivered
-		// at this same place on replay, delay the delivery until we reach such a safe place.  Signals that immediately
-		// terminate the program should not be delayed, however.
-		SIGPRINT ("Pid %d: not a safe place to record a signal - syscall is %d but last recorded syscall is %d ignore flag %d\n", current->pid, sysnum, psr->sysnum, ignore_flag);
-		return defer_signal (prt, signr, info);
-	}
-	return 0; // Will handle this signal later
+  if (ignore_flag && sysnum >= 0) {
+    return 0;
+  } else if (!sig_fatal(current,signr) && sysnum != psr->sysnum && sysnum != 0 /* restarted syscall */
+      // We don't ignore the signal if we have a custom signal handler for a syncrhonous sync signal 
+      && !(has_custom_handler(ka) && is_sync_signal(signr))) {
+    // This is an unrecorded system call or a trap.  Since we cannot guarantee that the signal will not delivered
+    // at this same place on replay, delay the delivery until we reach such a safe place.  Signals that immediately
+    // terminate the program should not be delayed, however.
+    SIGPRINT ("Pid %d: not a safe place to record a signal - syscall is %d but last recorded syscall is %d ignore flag %d\n", current->pid, sysnum, psr->sysnum, ignore_flag);
+    return defer_signal (prt, signr, info);
+  }
+  return 0; // Will handle this signal later
 }
 
 // This is a signal that will actually be handled, we need to record it
@@ -4988,13 +4999,15 @@ record_signal_delivery (int signr, siginfo_t* info, struct k_sigaction* ka)
 	int ignore_flag, need_fake_calls = 1;
 	int sysnum = syscall_get_nr(current, get_pt_regs(NULL));
 
+  printk("In record signal delivery\n");
+
 	if (prt->rp_ignore_flag_addr) {
 		get_user (ignore_flag, prt->rp_ignore_flag_addr);
 	} else {
 		ignore_flag = 0;
 	}
 
-        MPRINT ("Pid %d recording signal delivery signr %d fatal %d - clock is currently %d ignore flag %d sysnum %d psr->sysnum %d handler %p\n", 
+  MPRINT ("Pid %d recording signal delivery signr %d fatal %d - clock is currently %d ignore flag %d sysnum %d psr->sysnum %d handler %p\n", 
 		current->pid, signr, sig_fatal(current, signr), atomic_read(prt->rp_precord_clock), ignore_flag, sysnum, psr->sysnum, ka->sa.sa_handler);
 
 	// Note that a negative sysnum means we entered kernel via trap, interrupt, etc.  It is not safe to deliver a signal here, even in the ignore region because
@@ -5012,11 +5025,15 @@ record_signal_delivery (int signr, siginfo_t* info, struct k_sigaction* ka)
 		need_fake_calls++;
 		put_user (need_fake_calls, &phead->need_fake_calls);
 		MPRINT ("Pid %d record_signal inserts fake syscall - ignore_flag now %d, need_fake_calls now %d\n", current->pid, ignore_flag, need_fake_calls); 
-	} else if (!sig_fatal(current,signr) && sysnum != psr->sysnum && sysnum != 0 /* restarted syscall */) {
+	} else if (!sig_fatal(current,signr) && sysnum != psr->sysnum && sysnum != 0 /* restarted syscall */
+      // We don't ignore the signal if we have a custom signal handler for a syncrhonous sync signal 
+      && !(has_custom_handler(ka) && is_sync_signal(signr))) {
 		printk ("record_signal_delivery: this should have been handled!!!\n");
 		return -1;
 	}
+
 	if (sig_fatal(current,signr) && sysnum != psr->sysnum && sysnum != 0 /* restarted syscall */) {
+    printk("sig_fatal\n");
 		struct pthread_log_head __user* phead = (struct pthread_log_head __user *) prt->rp_user_log_addr;
 		// Sweet! There is always guaranteed to be allocated space for a record - also, we do not need to write out a full log since we are always the last record
 #ifdef USE_DEBUG_LOG
@@ -5024,6 +5041,7 @@ record_signal_delivery (int signr, siginfo_t* info, struct k_sigaction* ka)
 		MPRINT ("Pid %d: after signal, user code will not run again, so the kernel needs to insert a fake call for replay\n", current->pid);
 		get_user (pdata, &phead->next);
 		if (pdata) {
+      printk("pdata\n");
 			put_user (need_fake_calls, &pdata->retval); // Add the record - akin to what pthread_log.c in eglibc does
 			put_user (FAKE_SYSCALLS, &pdata->type);
 			pdata++;
@@ -5039,6 +5057,7 @@ record_signal_delivery (int signr, siginfo_t* info, struct k_sigaction* ka)
 		MPRINT ("Pid %d: after signal, user code will not run again, so the kernel needs to insert a fake call for replay\n", current->pid);
 		get_user (pnext, &phead->next);
 		if (pnext) {
+      printk("head_pointer\n");
 			get_user (entry, &phead->num_expected_records); 
 			entry |= FAKE_CALLS_FLAG;
 			put_user (entry, (u_long __user *) pnext);  
@@ -5060,38 +5079,45 @@ record_signal_delivery (int signr, siginfo_t* info, struct k_sigaction* ka)
 			new_syscall_exit (SIGNAL_WHILE_SYSCALL_IGNORED, NULL);
 			psr = &prt->rp_log[(prt->rp_in_ptr-1)]; 
 		}
+    printk("end fatal\n");
 	}
 
-	MPRINT ("Pid %d: recording and delivering signal\n", current->pid);
-	psignal = ARGSKMALLOC(sizeof(struct repsignal), GFP_KERNEL); 
-	if (psignal == NULL) {
-		printk ("Cannot allocate replay signal\n");
-		return 0;  // Replay broken - but might as well let recording proceed
-	}
-	psignal->signr = signr;
-	memcpy (&psignal->info, info, sizeof(siginfo_t));
-	memcpy (&psignal->ka, ka, sizeof(struct k_sigaction)); 
-	psignal->blocked = current->blocked;
-	psignal->real_blocked = current->real_blocked;
-	psignal->next = NULL;
-	
-	// Add signal to last record in log - will be delivered after syscall on replay
-	if ((psr->flags&SR_HAS_SIGNAL) == 0) {
-		psr->flags |= SR_HAS_SIGNAL;
-	} else {
-		prt->rp_last_signal->next = psignal;
-	}
-	prt->rp_last_signal = psignal;
+  if (has_custom_handler(ka) && is_sync_signal(signr)) {
+    printk("Ignoring sync signal with custom handler in recording\n");
+  } else {
+    MPRINT ("Pid %d: recording and delivering signal\n", current->pid);
+    psignal = ARGSKMALLOC(sizeof(struct repsignal), GFP_ATOMIC); 
+    printk("PSIGNAL MALLOC\n");
+    if (psignal == NULL) {
+      printk ("Cannot allocate replay signal\n");
+      return 0;  // Replay broken - but might as well let recording proceed
+    }
+    psignal->signr = signr;
+    memcpy (&psignal->info, info, sizeof(siginfo_t));
+    memcpy (&psignal->ka, ka, sizeof(struct k_sigaction)); 
+    psignal->blocked = current->blocked;
+    psignal->real_blocked = current->real_blocked;
+    psignal->next = NULL;
+    
+    // Add signal to last record in log - will be delivered after syscall on replay
+    if ((psr->flags&SR_HAS_SIGNAL) == 0) {
+      psr->flags |= SR_HAS_SIGNAL;
+    } else {
+      prt->rp_last_signal->next = psignal;
+    }
+    prt->rp_last_signal = psignal;
 
-	if (ka->sa.sa_handler > SIG_IGN) {
-		// Also save context from before signal
-		pcontext = KMALLOC (sizeof(struct repsignal_context), GFP_ATOMIC);
-		pcontext->ignore_flag = ignore_flag;
-		pcontext->next = prt->rp_repsignal_context_stack;
-		prt->rp_repsignal_context_stack = pcontext;
-		// If we were in an ignore region, that is no longer the case
-		if (prt->rp_ignore_flag_addr) put_user (0, prt->rp_ignore_flag_addr); 
-	}
+    if (ka->sa.sa_handler > SIG_IGN) {
+      // Also save context from before signal
+      pcontext = KMALLOC (sizeof(struct repsignal_context), GFP_ATOMIC);
+      printk("ATOMIC MALLOC\n");
+      pcontext->ignore_flag = ignore_flag;
+      pcontext->next = prt->rp_repsignal_context_stack;
+      prt->rp_repsignal_context_stack = pcontext;
+      // If we were in an ignore region, that is no longer the case
+      if (prt->rp_ignore_flag_addr) put_user (0, prt->rp_ignore_flag_addr); 
+    }
+  }
 
 	return 0;
 }
@@ -7718,6 +7744,9 @@ recplay_exit_start(void)
 	struct record_thread* prt = current->record_thrd;
 
 	DPRINT("recplay_exit_start \n");
+  if (replay_debug) {
+    dump_stack();
+  }
 
 	if (prt) {
 	    MPRINT ("Record thread %d starting to exit\n", current->pid);
@@ -12973,7 +13002,18 @@ replay_rt_sigaction (int sig, const struct sigaction __user *act, struct sigacti
 	}
 	else {
 		rc = get_next_syscall (174, &retparams);
+
 		if (rc == -EINTR && current->replay_thrd->rp_pin_attaching) return rc;
+
+    // Run sigaction anyway, that way if we get a user-level handled synchronous
+    //   signal its handled properly by the kernel signal delivery functions
+    printk("replay sigaction for sig: %d\n", sig);
+		retval = sys_rt_sigaction (sig, act, oact, sigsetsize);
+
+		if (rc != retval) {
+			printk("ERROR: sigaction mismatch, got %ld, expected %ld", retval, rc);
+			syscall_mismatch();
+		}
 	}
 
 	if (retparams) {
@@ -13048,7 +13088,13 @@ replay_rt_sigprocmask (int how, sigset_t __user *set, sigset_t __user *oset, siz
 		}
 	} else {
 		rc = get_next_syscall (175, &retparams);
+		retval = sys_rt_sigprocmask (how, set, oset, sigsetsize);
 		if (rc == -EINTR && current->replay_thrd->rp_pin_attaching) return rc;
+
+		if (rc != retval) {
+			printk("ERROR: sigprocmask expected %ld, got %ld\n", rc, retval);
+			syscall_mismatch();
+		}
 	}
 
 	if (retparams) {

--- a/linux-lts-quantal-3.5.0/kernel/signal.c
+++ b/linux-lts-quantal-3.5.0/kernel/signal.c
@@ -2430,7 +2430,7 @@ relock:
 		// Now that we have released siglock, we can do more complicated signal handling
 		// Note that some signals may be ignored - we should not need to record them
 		if (current->record_thrd && signr > 0) {
-			if (!(signr == 9 && SI_FROMKERNEL(info))) {
+			if (!(signr == SIGKILL && SI_FROMKERNEL(info))) {
 				if (record_signal_delivery(signr, info, &sighand->action[signr-1]) == -1) {
 					signr = 0;
 				}

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -10,7 +10,7 @@
 #
 #source $OMNIPLAY_DIR/scripts/common.sh
 
-function do_spec_setup() {
+function ensure_system_setup() {
 	if [[ ! -e /replay_cache ]]; then
 			sudo mkdir /replay_cache
 			sudo chmod a+rwx /replay_cache
@@ -21,6 +21,12 @@ function do_spec_setup() {
 			sudo chmod a+rwx /replay_logdb
 	fi
 
+	echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope &> /dev/null
+}
+
+function do_spec_setup() {
+  ensure_system_setup
+
 	sudo /sbin/insmod $OMNIPLAY_DIR/test/dev/spec.ko || {
 		echo "Unable to insert spec!"
 		return 1
@@ -30,8 +36,6 @@ function do_spec_setup() {
 			sudo mknod /dev/spec0 c 149 0
 			sudo chmod 777 /dev/spec0
 	fi
-
-	echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope &> /dev/null
 
 	return 0
 }

--- a/scripts/easy_launch.sh
+++ b/scripts/easy_launch.sh
@@ -14,6 +14,7 @@ if [[ "$#" -lt "1" ]]; then
 fi
 
 # Make sure spec is setup
+ensure_system_setup
 setup_spec
 
 # If we're recording... exit

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
 
-if [[ $(whoami) -ne "root" ]]; then
+if [[ $EUID -ne 0 ]]; then
     echo "Must be run as root!"
     exit 1
 fi
 
-user=$(who am i | awk '{print $1}')
+user=$SUDO_USER
+if [[ -z $SUDO_USER ]]; then
+  user=$(who am i | awk '{print $1}')
+fi
 
 
 custom_omniplay=0


### PR DESCRIPTION
Fixes a significant bug, where a recorded program with a custom signal handler would cause an infinite loop in recording (causing the kernel to crash).

Also fixes several smaller script bugs causing the scripts not to detect that the user isn't root, if the script was called from a non-login shell.